### PR TITLE
Allow the test framework to build, even on platforms that don't have XCTest

### DIFF
--- a/Sources/LoggerTestSupport/XCTest+Logger.swift
+++ b/Sources/LoggerTestSupport/XCTest+Logger.swift
@@ -4,6 +4,8 @@
 // For licensing terms, see http://elegantchaos.com/license/liberal/.
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+#if !os(iOS) || targetEnvironment(simulator)
+
 import XCTest
 import Logger
 
@@ -66,3 +68,5 @@ extension XCTestCase {
         XCTAssertTrue(testing(error))
     }
 }
+
+#endif


### PR DESCRIPTION
This is a workaround for a problem with Xcode project generation, which means that the LoggingTestSupport library may be built when targetting a real iOS device - even though XCTest is not available for real devices.