### PR TITLE
Fixes for timeout problem with XCTAssertFatalError

### DIFF
--- a/Sources/LoggerTestSupport/XCTest+Logger.swift
+++ b/Sources/LoggerTestSupport/XCTest+Logger.swift
@@ -20,6 +20,7 @@ extension XCTestCase {
     @discardableResult public func XCTAssertFatalError(timeout: TimeInterval = XCTestCase.DefaultFatalErrorTimeout, testcase: @escaping () -> Void) -> Any? {
         func unreachable() -> Never {
             repeat {
+                print("unreachable...")
                 RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
             } while (true)
         }

--- a/Sources/LoggerTestSupport/XCTest+Logger.swift
+++ b/Sources/LoggerTestSupport/XCTest+Logger.swift
@@ -10,8 +10,7 @@ import XCTest
 import Logger
 
 extension XCTestCase {
-    public static let DefaultFatalErrorTimeout = 2.0
-    
+    public static let DefaultFatalErrorTimeout = 1.0
 
     /**
      Assert that a fatal error has been reported via the Log Manager.
@@ -19,8 +18,9 @@ extension XCTestCase {
     
     @discardableResult public func XCTAssertFatalError(timeout: TimeInterval = XCTestCase.DefaultFatalErrorTimeout, testcase: @escaping () -> Void) -> Any? {
         func unreachable() -> Never {
+            // run forever, to simulate a function that never returns
             repeat {
-                RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: timeout))
             } while (true)
         }
 

--- a/Sources/LoggerTestSupport/XCTest+Logger.swift
+++ b/Sources/LoggerTestSupport/XCTest+Logger.swift
@@ -20,7 +20,6 @@ extension XCTestCase {
     @discardableResult public func XCTAssertFatalError(timeout: TimeInterval = XCTestCase.DefaultFatalErrorTimeout, testcase: @escaping () -> Void) -> Any? {
         func unreachable() -> Never {
             repeat {
-                print("unreachable...")
                 RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
             } while (true)
         }

--- a/Sources/LoggerTestSupport/XCTest+Logger.swift
+++ b/Sources/LoggerTestSupport/XCTest+Logger.swift
@@ -20,24 +20,24 @@ extension XCTestCase {
     @discardableResult public func XCTAssertFatalError(timeout: TimeInterval = XCTestCase.DefaultFatalErrorTimeout, testcase: @escaping () -> Void) -> Any? {
         func unreachable() -> Never {
             repeat {
-                RunLoop.current.run()
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 1.0))
             } while (true)
         }
 
         let expectation = self.expectation(description: "expectingFatalError")
         var fatalLogged: Any? = nil
         
-        let previousErrorHandler = Logger.defaultManager.installFatalErrorHandler() { logged, channel, _, _ in
+        let _ = Logger.defaultManager.installFatalErrorHandler() { logged, channel, _, _ in
             fatalLogged = logged
             expectation.fulfill()
             unreachable()
         }
         
-        DispatchQueue.global(qos: .userInitiated).async(execute: testcase)
+        DispatchQueue.global(qos: .default).async(execute: testcase)
         
         wait(for: [expectation], timeout: timeout)
         
-        let _ = Logger.defaultManager.installFatalErrorHandler(previousErrorHandler)
+        Logger.defaultManager.resetFatalErrorHandler()
         return fatalLogged
     }
  


### PR DESCRIPTION
This was timing out when running on travis-ci.org.
Not quite sure why, but I suspect some sort of deadlock inside `unreachable`.
Slightly changing the way things work seems to have fixed the issue.